### PR TITLE
#30: Fix CI dependency caching.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          keys: minify-inline-json-dependencies-{{ checksum "package-lock.json" }}
+          keys:
+            - minify-inline-json-dependencies-{{ checksum "package-lock.json" }}
       - run:
           name: install dependencies
           command: npm i

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.11
+* [#30: Fix CI dependency caching.](https://github.com/haensl/minify-inline-json/issues/30)
+
 ## 1.1.10
 * [#27: Update dependencies.](https://github.com/haensl/minify-inline-json/issues/27)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minify-inline-json",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Minify inlined/embedded JSON data within script tags",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## 1.1.11
* [#30: Fix CI dependency caching.](https://github.com/haensl/minify-inline-json/issues/30)

Closes #30